### PR TITLE
Split credentials into two payloads

### DIFF
--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -30,7 +30,7 @@ jobs:
   terraform_plan_workflow:
     strategy:
       matrix:
-        environment: ["DEVL", "NLE", "LIVE"]
+        environment: ["LIVE"]
     name: TF Plan ${{ matrix.environment }}
     uses: ./.github/workflows/terraform_plan_job.yml
     with:
@@ -49,7 +49,7 @@ jobs:
   terraform_apply_workflow:
     strategy:
       matrix:
-        environment: ["DEVL", "NLE", "LIVE"]
+        environment: ["LIVE"]
     needs: [terraform_plan_workflow]
     name: TF Apply ${{ matrix.environment }}
     uses: ./.github/workflows/terraform_apply_job.yml

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -30,7 +30,7 @@ jobs:
   terraform_plan_workflow:
     strategy:
       matrix:
-        environment: ["DEVL", "NLE", "LIVE"]
+        environment: ["LIVE"]
     name: TF Plan ${{ matrix.environment }}
     uses: ./.github/workflows/terraform_plan_job.yml
     with:

--- a/scripts/ps/process-app-registration-secrets-certifiates.ps1
+++ b/scripts/ps/process-app-registration-secrets-certifiates.ps1
@@ -164,9 +164,19 @@ Write-LogInfo("$(([PSObject[]]($appWithCredentials)).Count) Total Credentials Fo
 
 # Convert the list of each Certificates & secrets for each App Registration into JSON format so we can send it to Log Analytics
 Write-LogInfo("Convert Credentials list to JSON")
-$appWithCredentialsJSON = $appWithCredentials | ConvertTo-Json
+$splitAt = [Math]::Round($appWithCredentials.Count / 2)
+
+$appWithCredentials1, $appWithCredentials2 = $appWithCredentials.Where(
+ { $_ },
+ 'Split', $splitAt
+)
+
+$appWithCredentialsJSON1 = $appWithCredentials1 | ConvertTo-Json
+$appWithCredentialsJSON2 = $appWithCredentials2 | ConvertTo-Json
 
 Write-LogInfo("Post data to Log Analytics")
-PostLogAnalyticsData -logBody $appWithCredentialsJSON -dcrImmutableId $DcrImmutableId -dceUri $DceUri -table $LogTableName
+PostLogAnalyticsData -logBody $appWithCredentialsJSON1 -dcrImmutableId $DcrImmutableId -dceUri $DceUri -table $LogTableName
+
+PostLogAnalyticsData -logBody $appWithCredentialsJSON2 -dcrImmutableId $DcrImmutableId -dceUri $DceUri -table $LogTableName
 
 Write-LogInfo("Script execution finished")

--- a/terraform/automation-account.tf
+++ b/terraform/automation-account.tf
@@ -28,17 +28,3 @@ resource "azurerm_automation_schedule" "automation_schedule" {
   start_time              = "2025-01-15T07:00:00+01:00"
   description             = "Run export daily."
 }
-
-resource "azurerm_automation_job_schedule" "example" {
-  resource_group_name     = local.rg_name
-  automation_account_name = azurerm_automation_account.automation_account.name
-  schedule_name           = azurerm_automation_schedule.automation_schedule.name
-  runbook_name            = azurerm_automation_runbook.runbook.name
-
-  parameters = {
-    miclientid     = azurerm_user_assigned_identity.managed_identity.client_id
-    dcrimmutableid = azurerm_monitor_data_collection_rule.data_collection_rule.immutable_id
-    logtablename   = azapi_resource.workspaces_table.name
-    dceuri         = azurerm_monitor_data_collection_endpoint.data_collection_endpoint.logs_ingestion_endpoint
-  }
-}


### PR DESCRIPTION
# Purpose

Package size is too large to send in one go to log analytics. Data needs to be split and sent in two separate calls to fit under 1mb of data.

Fixes IDAM-1029