### PR TITLE
added DCR for credential cleanup

### DIFF
--- a/terraform/data-collection-rule.tf
+++ b/terraform/data-collection-rule.tf
@@ -144,6 +144,10 @@ resource "azurerm_monitor_data_collection_rule" "data_collection_rule_cleanup" {
       type = "datetime"
     }
     column {
+      name = "description"
+      type = "string"
+    }
+    column {
       name = "status"
       type = "string"
     }

--- a/terraform/data-collection-rule.tf
+++ b/terraform/data-collection-rule.tf
@@ -81,3 +81,91 @@ resource "azurerm_monitor_data_collection_rule" "data_collection_rule" {
 
   tags = local.tags
 }
+
+resource "azurerm_monitor_data_collection_rule" "data_collection_rule_cleanup" {
+  name                        = "dcr-${var.department}-${var.team}-${var.project}-cleanup"
+  location                    = var.location
+  resource_group_name         = local.rg_name
+  data_collection_endpoint_id = azurerm_monitor_data_collection_endpoint.data_collection_endpoint.id
+
+  destinations {
+    log_analytics {
+      workspace_resource_id = azurerm_log_analytics_workspace.log_analytics_workspace.id
+      name                  = azurerm_log_analytics_workspace.log_analytics_workspace.name
+    }
+  }
+
+  data_flow {
+    streams       = ["Custom-${azapi_resource.workspaces_table_creds_cleanup_script.name}"]
+    destinations  = [azurerm_log_analytics_workspace.log_analytics_workspace.name]
+    transform_kql = "source"
+    output_stream = "Custom-${azapi_resource.workspaces_table_creds_cleanup_script.name}"
+  }
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.managed_identity.id
+    ]
+  }
+
+  stream_declaration {
+    stream_name = "Custom-${azapi_resource.workspaces_table_creds_cleanup_script.name}"
+    column {
+      name = "displayname"
+      type = "string"
+    }
+    column {
+      name = "cleanup"
+      type = "string"
+    }
+    column {
+      name = "objectid"
+      type = "string"
+    }
+    column {
+      name = "applicationid"
+      type = "string"
+    }
+    column {
+      name = "keyid"
+      type = "string"
+    }
+    column {
+      name = "credtype"
+      type = "string"
+    }
+    column {
+      name = "startdate"
+      type = "datetime"
+    }
+    column {
+      name = "enddate"
+      type = "datetime"
+    }
+    column {
+      name = "status"
+      type = "string"
+    }
+    column {
+      name = "TimeGenerated"
+      type = "datetime"
+    }
+    column {
+      name = "daystoexpiration"
+      type = "int"
+    }
+    column {
+      name = "owners"
+      type = "string"
+    }
+  }
+
+  description = "Data collection rule for credential cleanup"
+  depends_on = [
+    azapi_resource.workspaces_table_creds_cleanup_script,
+    azurerm_monitor_data_collection_endpoint.data_collection_endpoint
+  ]
+
+  tags = local.tags
+}

--- a/terraform/managed-identity.tf
+++ b/terraform/managed-identity.tf
@@ -26,3 +26,15 @@ resource "azurerm_role_assignment" "assign_identity_dcr_monitoring_publisher" {
     azurerm_automation_account.automation_account,
   ]
 }
+
+resource "azurerm_role_assignment" "assign_identity_dcr_cleanup_monitoring_publisher" {
+  scope                = azurerm_monitor_data_collection_rule.data_collection_rule_cleanup.id
+  role_definition_name = "Monitoring Metrics Publisher"
+  principal_id         = azurerm_user_assigned_identity.managed_identity.principal_id
+
+  depends_on = [
+    azurerm_user_assigned_identity.managed_identity,
+    azurerm_automation_account.automation_account,
+  ]
+}
+

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -14,6 +14,10 @@ output "dcr_immutable_id" {
   value = azurerm_monitor_data_collection_rule.data_collection_rule.immutable_id
 }
 
+output "dcr_immutable_cleanup_id" {
+  value = azurerm_monitor_data_collection_rule.data_collection_rule_cleanup.immutable_id
+}
+
 output "log_table_name" {
   value = azapi_resource.workspaces_table.name
 }


### PR DESCRIPTION
# Purpose

Adding a data collection rule, this will be used to collect the data from the existing DCE to pass to the new log analytics table for expired credential cleanup. Also added a role assignment of the MI to the DCR

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
