### PR TITLE
re-introduced cleanup column and adjusted json object

### DIFF
--- a/scripts/ps/process-app-registration-creds-cleanup.ps1
+++ b/scripts/ps/process-app-registration-creds-cleanup.ps1
@@ -163,7 +163,7 @@ $ExpiredCredsTrimmed = $ExpiredCreds | sort daystoexpiration | select -First 1
 
                            [PSCustomObject]@{
                         displayname         = $ExpiredCred.displayname
-#                       cleanup             = $removal
+                        cleanup             = $removal
                         applicationid       = $ExpiredCred.applicationid
                         credtype            = $ExpiredCred.credtype
                         startdate           = $ExpiredCred.startdate
@@ -215,7 +215,7 @@ Write-LogInfo("$(([PSObject[]]($RemovedCreds)).Count) Total Expired Credentials 
 
 # Convert the list of each Certificates & secrets for each App Registration into JSON format so we can send it to Log Analytics
 Write-LogInfo("Convert Credentials list to JSON")
-$RemovedCredsJSON = $RemovedCreds | ConvertTo-Json
+$RemovedCredsJSON = ConvertTo-Json@($RemovedCreds)
 
 Write-LogInfo("Post data to Log Analytics")
 PostLogAnalyticsData -logBody $RemovedCredsJSON -dcrImmutableId $DcrImmutableId -dceUri $DceUri -table $LogTableName

--- a/terraform/data-collection-rule.tf
+++ b/terraform/data-collection-rule.tf
@@ -115,10 +115,10 @@ resource "azurerm_monitor_data_collection_rule" "data_collection_rule_cleanup" {
       name = "displayname"
       type = "string"
     }
-#    column {
-#      name = "cleanup"
-#      type = "string"
-#    }
+    column {
+      name = "cleanup"
+      type = "string"
+    }
     column {
       name = "applicationid"
       type = "string"

--- a/terraform/log-analytics-workspace-table.tf
+++ b/terraform/log-analytics-workspace-table.tf
@@ -79,10 +79,10 @@ resource "azapi_resource" "workspaces_table_creds_cleanup_script" {
             name = "displayname",
             type = "string"
           },
-#          {
-#            name = "cleanup",
-#            type = "string"
-#          },
+          {
+            name = "cleanup",
+            type = "string"
+          },
           {
             name = "objectid",
             type = "string"


### PR DESCRIPTION
# Purpose

Re-introduces the "cleanup" column and adjusts the JSON object

## Approach

The JSON output was getting rejected by loganalytics before as the JSON didn't contain square brackets []
This was because the script only returns a single object in this phase of testing, so adjusting the output ensures square brackets are present even when only a single result is present.

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
