### PR TITLE
updated cleanup to 15 items per run

### DIFF
--- a/scripts/ps/process-app-registration-creds-cleanup.ps1
+++ b/scripts/ps/process-app-registration-creds-cleanup.ps1
@@ -142,7 +142,7 @@ function GenerateCredentials() {
 
 function RemoveExpiredCredentials {
 
-$ExpiredCredsTrimmed = $ExpiredCreds | sort daystoexpiration | select -First 1
+$ExpiredCredsTrimmed = $ExpiredCreds | sort daystoexpiration | select -First 15
 
     $clean = foreach ($ExpiredCred in $ExpiredCredsTrimmed){
         write-host "Will remove cred from $(($ExpiredCred).displayname), keyID $(($ExpiredCred).keyid)."


### PR DESCRIPTION
# Purpose

Adjusts the credentials targeted from 1 to 15, this is to allow the script to run less frequently but run a broader cleanup

## Checklist

* [X] I have performed a self-review of my own code