### PR TITLE
Added array to handle single results

### DIFF
--- a/scripts/ps/process-app-registration-creds-cleanup.ps1
+++ b/scripts/ps/process-app-registration-creds-cleanup.ps1
@@ -136,7 +136,7 @@ function GenerateCredentials() {
     $ExpiredSecrets = $SecretApp | where {$_.status -EQ "Expired" -and $_.daystoexpiration -le -30}
     
     # Combine expired credentials
-    $ExpiredCerts + $ExpiredSecrets
+    [array]$ExpiredCerts + $ExpiredSecrets
     
 }
 


### PR DESCRIPTION
# Purpose

This script can fail to return results due to line 139, if a single item is returned from the query, it can fail to combine the results with this error:
`Method invocation failed because [System.Management.Automation.PSObject] does not contain a method named 'op_Addition'.
`
## Checklist

* [X] I have performed a self-review of my own code