### PR TITLE
Removing Import Commands from AccessPackage script

### DIFF
--- a/scripts/ps/Get-AccessPackage.ps1
+++ b/scripts/ps/Get-AccessPackage.ps1
@@ -5,10 +5,6 @@
     .DESCRIPTION
     Leverage Microsoft Graph API and PowerShell to fetch a list Catalogs, Access packages and groups #>
 
-
-    
-
-#Authentication to MS Graph
 param(
     [string]$MIclientId,
     [string]$DcrImmutableId,

--- a/scripts/ps/Get-AccessPackage.ps1
+++ b/scripts/ps/Get-AccessPackage.ps1
@@ -7,11 +7,7 @@
 
 
     
-#Importing required modules
-Import-Module microsoft.graph.beta.Identity.Governance
-import-module Microsoft.Graph.Identity.Governance
-Import-Module Microsoft.Graph.Groups
-#Using EUCS-IDAM-AccessPackage-Analytics-Test
+
 #Authentication to MS Graph
 param(
     [string]$MIclientId,


### PR DESCRIPTION
# Purpose

Removing import-module commands as this is not required in automation account

Fixes #

## Approach

deletes the lines of code

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the <TODO> service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
