### PR TITLE
Use `Get-MgGroup` instead of `Get-EntraGroup`

### DIFF
--- a/scripts/ps/process-guest-user-delete-devl.ps1
+++ b/scripts/ps/process-guest-user-delete-devl.ps1
@@ -89,7 +89,7 @@ catch
 }
 
 
-$group = Get-EntraGroup -Filter "displayName eq 'MoJo-External-Sync-Legal-Aid-Agency-Staff'"
+$group = Get-MgGroup -Filter "displayName eq 'MoJo-External-Sync-Legal-Aid-Agency-Staff'"
 
 $groupMembers = Get-MgGroupMember -GroupId $group.Id
 


### PR DESCRIPTION
# Purpose

Use `Get-MgGroup` instead of `Get-EntraGroup` in delete guest user script. Entra Group is not compatible with the versions we run in the runbook.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
