### PR TITLE
IDAM-4512 Connect schedule to runbook automatically

### DIFF
--- a/.github/workflows/terraform_apply_job.yml
+++ b/.github/workflows/terraform_apply_job.yml
@@ -64,7 +64,7 @@ jobs:
         run: terraform init -input=false
         env:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
-          TF_VAR_workspace: ${{ inputs.workspace_name }}
+          TF_VAR_workspace_name: ${{ inputs.workspace_name }}
           TF_VAR_subscription_id: ${{ secrets.workspace_subscription_id }}
           TF_VAR_tenant_id: ${{ secrets.workspace_tenant_id }}
           TF_VAR_client_id: ${{ secrets.workspace_client_id }}
@@ -75,7 +75,7 @@ jobs:
         id: terraform_plan
         env:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
-          TF_VAR_workspace: ${{ inputs.workspace_name }}
+          TF_VAR_workspace_name: ${{ inputs.workspace_name }}
           TF_VAR_subscription_id: ${{ secrets.workspace_subscription_id }}
           TF_VAR_tenant_id: ${{ secrets.workspace_tenant_id }}
           TF_VAR_client_id: ${{ secrets.workspace_client_id }}
@@ -88,7 +88,7 @@ jobs:
         id: terraform_apply
         env:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
-          TF_VAR_workspace: ${{ inputs.workspace_name }}
+          TF_VAR_workspace_name: ${{ inputs.workspace_name }}
           TF_VAR_subscription_id: ${{ secrets.workspace_subscription_id }}
           TF_VAR_tenant_id: ${{ secrets.workspace_tenant_id }}
           TF_VAR_client_id: ${{ secrets.workspace_client_id }}

--- a/.github/workflows/terraform_apply_job.yml
+++ b/.github/workflows/terraform_apply_job.yml
@@ -64,6 +64,7 @@ jobs:
         run: terraform init -input=false
         env:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
+          TF_VAR_workspace: ${{ inputs.workspace_name }}
           TF_VAR_subscription_id: ${{ secrets.workspace_subscription_id }}
           TF_VAR_tenant_id: ${{ secrets.workspace_tenant_id }}
           TF_VAR_client_id: ${{ secrets.workspace_client_id }}
@@ -74,6 +75,7 @@ jobs:
         id: terraform_plan
         env:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
+          TF_VAR_workspace: ${{ inputs.workspace_name }}
           TF_VAR_subscription_id: ${{ secrets.workspace_subscription_id }}
           TF_VAR_tenant_id: ${{ secrets.workspace_tenant_id }}
           TF_VAR_client_id: ${{ secrets.workspace_client_id }}
@@ -86,6 +88,7 @@ jobs:
         id: terraform_apply
         env:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
+          TF_VAR_workspace: ${{ inputs.workspace_name }}
           TF_VAR_subscription_id: ${{ secrets.workspace_subscription_id }}
           TF_VAR_tenant_id: ${{ secrets.workspace_tenant_id }}
           TF_VAR_client_id: ${{ secrets.workspace_client_id }}

--- a/.github/workflows/terraform_plan_job.yml
+++ b/.github/workflows/terraform_plan_job.yml
@@ -69,6 +69,7 @@ jobs:
         run: terraform init -input=false
         env:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
+          TF_VAR_workspace: ${{ inputs.workspace_name }}
           TF_VAR_subscription_id: ${{ secrets.workspace_subscription_id }}
           TF_VAR_tenant_id: ${{ secrets.workspace_tenant_id }}
           TF_VAR_client_id: ${{ secrets.workspace_client_id }}
@@ -79,6 +80,7 @@ jobs:
         run: terraform validate
         env:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
+          TF_VAR_workspace: ${{ inputs.workspace_name }}
           TF_VAR_subscription_id: ${{ secrets.workspace_subscription_id }}
           TF_VAR_tenant_id: ${{ secrets.workspace_tenant_id }}
           TF_VAR_client_id: ${{ secrets.workspace_client_id }}
@@ -89,6 +91,7 @@ jobs:
         id: terraform_plan
         env:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
+          TF_VAR_workspace: ${{ inputs.workspace_name }}
           TF_VAR_subscription_id: ${{ secrets.workspace_subscription_id }}
           TF_VAR_tenant_id: ${{ secrets.workspace_tenant_id }}
           TF_VAR_client_id: ${{ secrets.workspace_client_id }}

--- a/.github/workflows/terraform_plan_job.yml
+++ b/.github/workflows/terraform_plan_job.yml
@@ -69,7 +69,7 @@ jobs:
         run: terraform init -input=false
         env:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
-          TF_VAR_workspace: ${{ inputs.workspace_name }}
+          TF_VAR_workspace_name: ${{ inputs.workspace_name }}
           TF_VAR_subscription_id: ${{ secrets.workspace_subscription_id }}
           TF_VAR_tenant_id: ${{ secrets.workspace_tenant_id }}
           TF_VAR_client_id: ${{ secrets.workspace_client_id }}
@@ -80,7 +80,7 @@ jobs:
         run: terraform validate
         env:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
-          TF_VAR_workspace: ${{ inputs.workspace_name }}
+          TF_VAR_workspace_name: ${{ inputs.workspace_name }}
           TF_VAR_subscription_id: ${{ secrets.workspace_subscription_id }}
           TF_VAR_tenant_id: ${{ secrets.workspace_tenant_id }}
           TF_VAR_client_id: ${{ secrets.workspace_client_id }}
@@ -91,7 +91,7 @@ jobs:
         id: terraform_plan
         env:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
-          TF_VAR_workspace: ${{ inputs.workspace_name }}
+          TF_VAR_workspace_name: ${{ inputs.workspace_name }}
           TF_VAR_subscription_id: ${{ secrets.workspace_subscription_id }}
           TF_VAR_tenant_id: ${{ secrets.workspace_tenant_id }}
           TF_VAR_client_id: ${{ secrets.workspace_client_id }}

--- a/terraform/automation-account.tf
+++ b/terraform/automation-account.tf
@@ -26,7 +26,7 @@ resource "azurerm_automation_schedule" "automation_schedule" {
   interval                = 1
   timezone                = "Europe/London"
   start_time              = "2025-10-01T07:00:00+01:00"
-  description             = "Run export daily."
+  description             = "Run daily application registration credential report."
 }
 
 resource "azurerm_automation_job_schedule" "automation_job_schedule" {
@@ -60,8 +60,8 @@ resource "azurerm_automation_schedule" "automation_schedule_guest_users" {
   frequency               = "Day"
   interval                = 1
   timezone                = "Europe/London"
-  start_time              = "2025-09-16T07:00:00+01:00"
-  description             = "Run export daily."
+  start_time              = "2025-10-01T07:00:00+01:00"
+  description             = "Run Guest User reporting daily."
 }
 
 resource "azurerm_automation_job_schedule" "automation_job_schedule_guest_users" {
@@ -86,8 +86,23 @@ resource "azurerm_automation_schedule" "automation_schedule_Access_Package" {
   frequency               = "Day"
   interval                = 14
   timezone                = "Europe/London"
-  start_time              = "2025-09-16T07:00:00+01:00"
+  start_time              = "2025-10-01T07:00:00+01:00"
   description             = "Run AccessPackage runbook every 2 weeks."
+}
+
+resource "azurerm_automation_job_schedule" "automation_job_schedule_Access_Package" {
+  count = var.workspace_name == "LIVE" ? 1 : 0
+
+  resource_group_name     = local.rg_name
+  automation_account_name = azurerm_automation_account.automation_account.name
+  runbook_name            = azurerm_automation_runbook.runbook_Access_Package_info_script.name
+  schedule_name           = azurerm_automation_schedule.automation_schedule_Access_Package.name
+  parameters = {
+    miclientid     = azurerm_user_assigned_identity.managed_identity.client_id,
+    dcrimmutableid = azurerm_monitor_data_collection_rule.data_collection_rule_AccessPackage.immutable_id,
+    dceuri         = azurerm_monitor_data_collection_endpoint.data_collection_endpoint.logs_ingestion_endpoint,
+    logtablename   = azapi_resource.workspaces_table_access_package_info.name
+  }
 }
 
 resource "azurerm_automation_schedule" "automation_schedule_guest_del" {
@@ -97,6 +112,21 @@ resource "azurerm_automation_schedule" "automation_schedule_guest_del" {
   frequency               = "Day"
   interval                = 1
   timezone                = "Europe/London"
-  start_time              = "2025-09-26T07:00:00+01:00"
+  start_time              = "2025-10-01T07:00:00+01:00"
   description             = "Run Guest User Delete every day."
+}
+
+resource "azurerm_automation_job_schedule" "automation_job_schedule_guest_del" {
+  count = var.workspace_name == "DEVLEXTERNAL" ? 1 : 0
+
+  resource_group_name     = local.rg_name
+  automation_account_name = azurerm_automation_account.automation_account.name
+  runbook_name            = azurerm_automation_runbook.runbook_guest_del_devl.name
+  schedule_name           = azurerm_automation_schedule.automation_schedule_guest_del.name
+  parameters = {
+    miclientid     = azurerm_user_assigned_identity.managed_identity.client_id,
+    dcrimmutableid = azurerm_monitor_data_collection_rule.data_collection_rule_guest_del.immutable_id,
+    dceuri         = azurerm_monitor_data_collection_endpoint.data_collection_endpoint.logs_ingestion_endpoint,
+    logtablename   = azapi_resource.workspaces_table_guest_del_script.name
+  }
 }

--- a/terraform/automation-account.tf
+++ b/terraform/automation-account.tf
@@ -35,10 +35,10 @@ resource "azurerm_automation_job_schedule" "automation_job_schedule" {
   runbook_name            = azurerm_automation_runbook.runbook.name
   schedule_name           = azurerm_automation_schedule.automation_schedule.name
   parameters = { 
-    MiClientId     = azurerm_user_assigned_identity.managed_identity.client_id,
-    DcrImmutableId = azurerm_monitor_data_collection_rule.data_collection_rule.immutable_id,
-    DceUri         = azurerm_monitor_data_collection_endpoint.data_collection_endpoint.logs_ingestion_endpoint,
-    LogTableName   = azapi_resource.workspaces_table.name
+    miclientid     = azurerm_user_assigned_identity.managed_identity.client_id,
+    dcrimmutableid = azurerm_monitor_data_collection_rule.data_collection_rule.immutable_id,
+    dceuri         = azurerm_monitor_data_collection_endpoint.data_collection_endpoint.logs_ingestion_endpoint,
+    logtablename   = azapi_resource.workspaces_table.name
   }
 }
 

--- a/terraform/automation-account.tf
+++ b/terraform/automation-account.tf
@@ -34,7 +34,7 @@ resource "azurerm_automation_job_schedule" "automation_job_schedule" {
   automation_account_name = azurerm_automation_account.automation_account.name
   runbook_name            = azurerm_automation_runbook.runbook.name
   schedule_name           = azurerm_automation_schedule.automation_schedule.name
-  parameters = { 
+  parameters = {
     miclientid     = azurerm_user_assigned_identity.managed_identity.client_id,
     dcrimmutableid = azurerm_monitor_data_collection_rule.data_collection_rule.immutable_id,
     dceuri         = azurerm_monitor_data_collection_endpoint.data_collection_endpoint.logs_ingestion_endpoint,

--- a/terraform/automation-account.tf
+++ b/terraform/automation-account.tf
@@ -35,10 +35,10 @@ resource "azurerm_automation_job_schedule" "automation_job_schedule" {
   runbook_name            = azurerm_automation_runbook.runbook.name
   schedule_name           = azurerm_automation_schedule.automation_schedule.name
   parameters = { 
-    "MiClientId"     = azurerm_user_assigned_identity.managed_identity.client_id,
-    "DcrImmutableId" = azurerm_monitor_data_collection_rule.data_collection_rule.immutable_id,
-    "DceUri"         = azurerm_monitor_data_collection_endpoint.data_collection_endpoint.logs_ingestion_endpoint,
-    "LogTableName"   = azapi_resource.workspaces_table.name
+    MiClientId     = azurerm_user_assigned_identity.managed_identity.client_id,
+    DcrImmutableId = azurerm_monitor_data_collection_rule.data_collection_rule.immutable_id,
+    DceUri         = azurerm_monitor_data_collection_endpoint.data_collection_endpoint.logs_ingestion_endpoint,
+    LogTableName   = azapi_resource.workspaces_table.name
   }
 }
 

--- a/terraform/automation-account.tf
+++ b/terraform/automation-account.tf
@@ -25,8 +25,21 @@ resource "azurerm_automation_schedule" "automation_schedule" {
   frequency               = "Day"
   interval                = 1
   timezone                = "Europe/London"
-  start_time              = "2025-09-30T07:00:00+01:00"
+  start_time              = "2025-10-01T07:00:00+01:00"
   description             = "Run export daily."
+}
+
+resource "azurerm_automation_job_schedule" "automation_job_schedule" {
+  resource_group_name     = local.rg_name
+  automation_account_name = azurerm_automation_account.automation_account.name
+  runbook_name            = azurerm_automation_runbook.runbook.name
+  schedule_name           = azurerm_automation_schedule.automation_schedule.name
+  parameters = { 
+    "MiClientId"     = azurerm_user_assigned_identity.managed_identity.client_id,
+    "DcrImmutableId" = azurerm_monitor_data_collection_rule.data_collection_rule.immutable_id,
+    "DceUri"         = azurerm_monitor_data_collection_endpoint.data_collection_endpoint.logs_ingestion_endpoint,
+    "LogTableName"   = azapi_resource.workspaces_table.name
+  }
 }
 
 resource "azurerm_automation_schedule" "automation_schedule_cleanup" {

--- a/terraform/automation-account.tf
+++ b/terraform/automation-account.tf
@@ -64,6 +64,21 @@ resource "azurerm_automation_schedule" "automation_schedule_guest_users" {
   description             = "Run export daily."
 }
 
+resource "azurerm_automation_job_schedule" "automation_job_schedule_guest_users" {
+  count = var.workspace_name == "DEVLEXTERNAL" || var.workspace_name == "LIVE" || var.workspace_name == "LIVEEXTERNAL" ? 1 : 0
+
+  resource_group_name     = local.rg_name
+  automation_account_name = azurerm_automation_account.automation_account.name
+  runbook_name            = azurerm_automation_runbook.runbook_guest_users_script.name
+  schedule_name           = azurerm_automation_schedule.automation_schedule_guest_users.name
+  parameters = {
+    miclientid     = azurerm_user_assigned_identity.managed_identity.client_id,
+    dcrimmutableid = azurerm_monitor_data_collection_rule.data_collection_rule_guest_users.immutable_id,
+    dceuri         = azurerm_monitor_data_collection_endpoint.data_collection_endpoint.logs_ingestion_endpoint,
+    logtablename   = azapi_resource.workspaces_table_guest_users.name
+  }
+}
+
 resource "azurerm_automation_schedule" "automation_schedule_Access_Package" {
   name                    = "as-${var.department}-${var.team}-${var.project}-access-package"
   resource_group_name     = local.rg_name

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,13 +2,15 @@ output "resource_group_name" {
   value = local.rg_name
 }
 
-output "configuration_access_endpoint" {
-  value = azurerm_monitor_data_collection_endpoint.data_collection_endpoint.configuration_access_endpoint
-}
-
 output "managed_identity_client_id" {
   value = azurerm_user_assigned_identity.managed_identity.client_id
 }
+
+output "dceuri" {
+  value = azurerm_monitor_data_collection_endpoint.data_collection_endpoint.logs_ingestion_endpoint
+}
+
+# Immutable IDs
 
 output "dcr_immutable_id" {
   value = azurerm_monitor_data_collection_rule.data_collection_rule.immutable_id
@@ -16,6 +18,10 @@ output "dcr_immutable_id" {
 
 output "dcr_immutable_cleanup_id" {
   value = azurerm_monitor_data_collection_rule.data_collection_rule_cleanup.immutable_id
+}
+
+output "dcr_immutable_accesspackage_id" {
+  value = azurerm_monitor_data_collection_rule.data_collection_rule_AccessPackage.immutable_id
 }
 
 output "dcr_immutable_guest_users_id" {
@@ -26,14 +32,25 @@ output "dcr_immutable_guest_del_id" {
   value = azurerm_monitor_data_collection_rule.data_collection_rule_guest_del.immutable_id
 }
 
-output "log_table_name" {
+# Log Table Names
+
+output "log_table_workspaces_table" {
   value = azapi_resource.workspaces_table.name
 }
 
-output "log_table_name_creds_cleanup_script" {
+output "log_table_workspaces_table_access_package_info" {
+  value = azapi_resource.workspaces_table_access_package_info.name
+}
+
+output "log_table_workspaces_table_creds_cleanup_script" {
   value = azapi_resource.workspaces_table_creds_cleanup_script.name
 }
 
-output "dceuri" {
-  value = azurerm_monitor_data_collection_endpoint.data_collection_endpoint.logs_ingestion_endpoint
+output "log_table_workspaces_table_guest_users" {
+  value = azapi_resource.workspaces_table_guest_users.name
 }
+
+output "log_table_workspaces_table_guest_del_script" {
+  value = azapi_resource.workspaces_table_guest_del_script.name
+}
+

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,7 @@
+output "workspace_name" {
+  value = var.workspace_name
+}
+
 output "resource_group_name" {
   value = local.rg_name
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,8 @@
+variable "workspace_name" {
+  type        = string
+  description = "The name of the current workspace being run."
+}
+
 variable "subscription_id" {
   type        = string
   description = "Azure Subscription ID."


### PR DESCRIPTION
# Purpose

Fixes the issue of Runbooks and Schedules not linking automatically and being reset after an update is made.

Update includes

* Creating new `azurerm_automation_job_schedule` for each `azurerm_automation_schedule` to tie them together. **This does not include the Credential Cleanup script as a seperate PR to pass additional email parameters is required.**
* Pass the Workspace Name into Terraform from GitHub Actions
* Add conditional logic to each `azurerm_automation_job_schedule` to ensure only tenants that should run the scripts are set.
* Tidy outputs to show all required vars after a run

## Overview of tenant/job setup

### App Registration Credential Reporting

* All Tenants

### Guest User Reporting

* `DEVLEXTERNAL`
* `LIVE`
* `LIVEEXTERNAL`

### Access Package Reporting

* `LIVE`

### Guest User Deletion

* `DEVLEXTERNAL`

Fixes https://dsdmoj.atlassian.net/browse/IDAM-4512

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
